### PR TITLE
comply with XDG Base Directory Specification (fixes #13)

### DIFF
--- a/rapport/config.py
+++ b/rapport/config.py
@@ -23,17 +23,21 @@ except ImportError:
 
 import rapport.config
 
+XDG_CONFIG_HOME_DIR = os.getenv('XDG_CONFIG_HOME') or \
+                      os.path.expanduser(os.path.join("~", ".config"))
+USER_CONFIG_DIR     = os.path.join(XDG_CONFIG_HOME_DIR, "rapport")
+USER_CONFIG_FILE    = os.path.join(USER_CONFIG_DIR, "rapport.conf")
 
 def _get_config_dirs():
     """Return a list of directories where config files may be located.
 
     The following directories are returned::
 
-      ~/.rapport/
+      $XDG_CONFIG_HOME/rapport/ ($XDG_CONFIG_HOME defaults to ~/.config)
       /etc/rapport/
     """
     config_dirs = [
-        os.path.expanduser(os.path.join("~", ".rapport")),
+        USER_CONFIG_DIR,
         os.path.join("/", "etc", "rapport"),
         os.path.abspath(os.path.join("rapport", "config"))
     ]
@@ -55,19 +59,16 @@ def find_config_files():
 
 
 def init_user():
-    """Create and populate the ~/.rapport directory tree if it's not existing.
+    """Create and populate the ~/.config/rapport directory tree if it's not existing.
 
     Doesn't interfere with already existing directories or configuration files.
     """
-    user_conf_dir = os.path.expanduser(os.path.join("~", ".rapport"))
-    user_conf_file = os.path.join(user_conf_dir, "rapport.conf")
-
-    if not os.path.exists(user_conf_dir):
+    if not os.path.exists(USER_CONFIG_DIR):
         if rapport.config.get_int("rapport", "verbosity") >= 1:
-            print("Create user directory {0}".format(user_conf_dir))
-        os.makedirs(user_conf_dir)
+            print("Create user directory {0}".format(USER_CONFIG_DIR))
+        os.makedirs(USER_CONFIG_DIR)
     for subdir in ["plugins", "reports", "templates/plugin", "templates/email", "templates/web"]:
-        user_conf_subdir = os.path.join(user_conf_dir, subdir)
+        user_conf_subdir = os.path.join(USER_CONFIG_DIR, subdir)
         if not os.path.exists(user_conf_subdir):
             if rapport.config.get_int("rapport", "verbosity") >= 1:
                 print("Create user directory {0}".format(user_conf_subdir))
@@ -76,16 +77,16 @@ def init_user():
             if rapport.config.get_int("rapport", "verbosity") >= 1:
                 print("Set secure directory permissions for {0}".format(user_conf_subdir))
             os.chmod(user_conf_subdir, 0o700)
-    if not os.path.exists(user_conf_file):
+    if not os.path.exists(USER_CONFIG_FILE):
         if rapport.config.get_int("rapport", "verbosity") >= 1:
-            print("Create user configuration {0}".format(user_conf_file))
+            print("Create user configuration {0}".format(USER_CONFIG_FILE))
         default_config = os.path.abspath(os.path.join(os.path.splitext(__file__)[0], "rapport.conf"))
-        shutil.copyfile(default_config, user_conf_file)
+        shutil.copyfile(default_config, USER_CONFIG_FILE)
 
-    if not (os.stat(user_conf_file).st_mode & 0o777) == 0o600:
+    if not (os.stat(USER_CONFIG_FILE).st_mode & 0o777) == 0o600:
         if rapport.config.get_int("rapport", "verbosity") >= 1:
-            print("Set secure file permissions for {0}".format(user_conf_file))
-        os.chmod(user_conf_file, 0o600)
+            print("Set secure file permissions for {0}".format(USER_CONFIG_FILE))
+        os.chmod(USER_CONFIG_FILE, 0o600)
 
 
 CONF = None

--- a/rapport/plugin.py
+++ b/rapport/plugin.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     import urlparse
 
+from rapport.config import USER_CONFIG_DIR
 import rapport.config
 import rapport.util
 
@@ -79,7 +80,7 @@ def _get_plugin_dirs():
     """Return a list of directories where plugins may be located.
     """
     plugin_dirs = [
-        os.path.expanduser(os.path.join("~", ".rapport", "plugins")),
+        os.path.expanduser(os.path.join(USER_CONFIG_DIR, "plugins")),
         os.path.join("rapport", "plugins")  # Local dev tree
     ]
     return plugin_dirs

--- a/rapport/report.py
+++ b/rapport/report.py
@@ -27,13 +27,17 @@ import traceback
 
 import jinja2
 
-import rapport.config
+XDG_CONFIG_DATA_DIR = os.getenv('XDG_DATA_HOME') or \
+                      os.path.expanduser(os.path.join("~", ".local", "share"))
+USER_DATA_DIR       = os.path.join(XDG_CONFIG_DATA_DIR, "rapport")
+
+from rapport.config import USER_CONFIG_DIR
 import rapport.template
 import rapport.util
 
 
 def _get_reports_path(report=None):
-    path_parts = ["~", ".rapport", "reports"]
+    path_parts = [USER_DATA_DIR, "reports"]
     if report:
         path_parts.append(report)
     return os.path.expanduser(os.path.join(*path_parts))

--- a/rapport/template.py
+++ b/rapport/template.py
@@ -19,12 +19,13 @@ import sys
 
 import jinja2
 
+from rapport.config import USER_CONFIG_DIR
 
 def _get_template_dirs(type="plugin"):
     """Return a list of directories where templates may be located.
     """
     template_dirs = [
-        os.path.expanduser(os.path.join("~", ".rapport", "templates", type)),
+        os.path.expanduser(os.path.join(USER_CONFIG_DIR, "templates", type)),
         os.path.join("rapport", "templates", type)  # Local dev tree
     ]
     return template_dirs

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -22,6 +22,6 @@ import rapport.config
 class ConfigTestCase(unittest.TestCase):
     def test__get_config_dirs(self):
         config_dirs = rapport.config._get_config_dirs()
-        self.assertIn(os.path.expanduser(os.path.join("~", ".rapport")), config_dirs)
+        self.assertIn(os.path.expanduser(os.path.join("~", ".config", "rapport")), config_dirs)
         self.assertIn(os.path.join("/etc", "rapport"), config_dirs)
         self.assertIn(os.path.abspath(os.path.join("rapport", "config")), config_dirs)

--- a/test/unit/test_plugin.py
+++ b/test/unit/test_plugin.py
@@ -22,4 +22,4 @@ import rapport.plugin
 class PluginTestCase(unittest.TestCase):
     def test__get_plugin_dirs(self):
         plugin_dirs = rapport.plugin._get_plugin_dirs()
-        self.assertIn(os.path.expanduser(os.path.join("~", ".rapport", "plugins")), plugin_dirs)
+        self.assertIn(os.path.expanduser(os.path.join("~", ".config", "rapport", "plugins")), plugin_dirs)

--- a/test/unit/test_reports.py
+++ b/test/unit/test_reports.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2013, Sascha Peilicke <saschpe@gmx.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+
+
+import os
+import unittest
+
+import rapport.report
+
+
+class ReportsTestCase(unittest.TestCase):
+    def test__get_reports_path(self):
+        reports_path = rapport.report._get_reports_path()
+        self.assertIn(os.path.expanduser(os.path.join("~", ".local", "share", "rapport", "reports")), reports_path)

--- a/test/unit/test_template.py
+++ b/test/unit/test_template.py
@@ -23,5 +23,5 @@ class TemplateTestCase(unittest.TestCase):
     def test__get_template_dirs(self):
         for type in ["plugin", "email", "web"]:
             template_dirs = rapport.template._get_template_dirs(type)
-            self.assertIn(os.path.expanduser(os.path.join("~", ".rapport", "templates", type)), template_dirs)
+            self.assertIn(os.path.expanduser(os.path.join("~", ".config", "rapport", "templates", type)), template_dirs)
             self.assertIn(os.path.join("rapport", "templates", type), template_dirs)


### PR DESCRIPTION
User config tree now defaults to `~/.config/rapport`

I'm not 100% sure this works yet, because I still have a test failure ...
